### PR TITLE
Remove "eskerrik" and some other fixes

### DIFF
--- a/courses/basque-from-english/02-QuestionsGreetings/skills/02-greetings-1.yaml
+++ b/courses/basque-from-english/02-QuestionsGreetings/skills/02-greetings-1.yaml
@@ -6,7 +6,7 @@ Skill:
 
 New words:
   - Word: Arratsalde on
-    Translation: Good Afternoon
+    Translation: Good afternoon
     Images:
       - afternoon1
       - afternoon2
@@ -19,26 +19,21 @@ New words:
     Images:
 
 
-  - Word: berdin
-    Translation: fine
+  - Word: Berdin!
+    Translation: Same to you!
+    Also accepted:
+      - same
     Images:
       - imfine1
       - imfine2
       - imfine3
 
   - Word: Egon on
-    Translation: Good Morning
+    Translation: Good morning
     Images:
       - morning1
       - morning2
       - morning3
-
-  - Word: Eskerrik
-    Translation: thanks
-    Images:
-      - thankyou1
-      - thankyou2
-      - thankyou3
 
   - Word: Eskerrik asko
     Translation: Thank you
@@ -48,10 +43,11 @@ New words:
       - thankyou3
 
   - Word: ondo
-    Translation: good
+    Translation: well
     Also accepted:
       - fine
       - OK
+      - good
     Images:
       - imfine2
       - imfine3
@@ -74,10 +70,12 @@ New words:
 
 Phrases:
   - Phrase: Barkatu. Nor zara zu?
+    Alternative versions:
+     - Barkatu. Nor zara?
     Translation: Excuse me. Who are you?
 
   - Phrase: Egun on. Zer moduz?
-    Translation: Good Morning. How are you?
+    Translation: Good morning. How are you?
 
   - Phrase: Gu Mikel eta Joseba gara.
     Alternative versions:
@@ -94,10 +92,12 @@ Phrases:
      - Mikel eta Miren dira?
     Translation: Are they Mikel and Miren?
 
-  - Phrase: Arratsalde on. Zu al Mikel zara?
+  - Phrase: Arratsalde on. Zu Mikel al zara?
     Alternative versions:
-     - Arratsalde on. Al Mikel zara?
-    Translation: Good Afternoon. Are you Mikel?
+     - Arratsalde on. Mikel al zara?
+     - Arratsalde on. Mikel zara?
+     - Arratsalde on. Zu Mikel zara?
+    Translation: Good afternoon. Are you Mikel?
 
   - Phrase: Zu ondo zara?
     Alternative versions:
@@ -159,7 +159,7 @@ Mini-dictionary:
     - eta: and
     - on: good
     - ondo:
-      - good
+      - well
       - OK
       - fine
     - gara: are


### PR DESCRIPTION
## Description

- Removed "eskerrik" as it's not used on its own.
- Made some other changes (fixed position of "al", have we taught that?).
- There is an issue with "ondo", in Basque you generally use "ondo" with "egon": Ondo gaude (not gara). Using "gara" instead of "gaude" is more typical of northern (French) dialects but is not how most people speak (seeing as most people speak southern/Spanish dialects). "Egon" describes *how* you are where as "izan" (the *gara* form) describes "what" you are. It can also describe "where" you are, though "egon" has taken its place in many dialects, perhaps making egon/izan closer to estar/ser in Spanish. If we want to use "ondo" here, a sentence like "-Zer moduz? -Ondo, eskerrik asko" might be a better choice, as we can avoid the verb which we haven't learned yet.

I haven't finished going through this one, just wanted to comment on "ondo" before going further.